### PR TITLE
Linking Error handling

### DIFF
--- a/src/WebViewShared.tsx
+++ b/src/WebViewShared.tsx
@@ -53,7 +53,9 @@ const createOnShouldStartLoadWithRequest = (
     const { url, lockIdentifier } = nativeEvent;
 
     if (!passesWhitelist(compileWhitelist(originWhitelist), url)) {
-      Linking.openURL(url);
+      Linking.openURL(url).catch(
+           err => this.props.onError && this.props.onError(err),
+         );
       shouldStart = false;
     }
 


### PR DESCRIPTION
When we have open url that redirected to installed app. than react-native-webview not handle error to redirectting on that app.